### PR TITLE
log-generator: don't disable header check eslint rule

### DIFF
--- a/log-generator/.eslintrc.js
+++ b/log-generator/.eslintrc.js
@@ -5,10 +5,5 @@
 
 'use strict'
 module.exports = {
-  extends: '@newrelic',
-  overrides: [
-    {
-      files: ['log-generator.js']
-    }
-  ]
+  extends: '@newrelic'
 }


### PR DESCRIPTION
Oops, this should have been part of the previous PR on the
log-generator.