### PR TITLE
update examples to use v3 of the winston enricher

### DIFF
--- a/log-generator/log-generator.js
+++ b/log-generator/log-generator.js
@@ -108,9 +108,10 @@ function getRandomLogLevel() {
 function getLogger(logtype) {
   let logger
   if (logtype === 'winston') {
-    const newrelicFormatter = require('@newrelic/winston-enricher')
+    const winston = require('winston')
+    const newrelicFormatter = require('@newrelic/winston-enricher')(winston)
+    const { createLogger, format, transports } = winston
 
-    const { createLogger, format, transports } = require('winston')
     logger = createLogger({
       level: 'debug',
       format: format.combine(

--- a/log-generator/package-lock.json
+++ b/log-generator/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "dependencies": {
         "@newrelic/pino-enricher": "^0.1.0",
-        "@newrelic/winston-enricher": "^2.1.2",
+        "@newrelic/winston-enricher": "^3.0.0",
         "faker": "^5.5.3",
         "newrelic": "^8.9.1",
         "pino": "^7.9.2",
@@ -324,15 +324,14 @@
       }
     },
     "node_modules/@newrelic/winston-enricher": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/winston-enricher/-/winston-enricher-2.1.2.tgz",
-      "integrity": "sha512-9LVwFvGd0QwQbEbKO1VGx47saxF4abvWG69abIYAGPVOOPPZMtf13hFXwE/1/pT73AP6xntgn4bFwM4gZmg1NA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/winston-enricher/-/winston-enricher-3.0.0.tgz",
+      "integrity": "sha512-fb9FRMPufM+GrI3wjtAorpgi/wTRBabK6a6Hcknl5Db71YqjdU4lDsebCbPhOSNGadpANLcIHoSsZEqu8MUwXw==",
       "engines": {
         "node": ">=12.0"
       },
       "peerDependencies": {
-        "newrelic": ">=6.2.0",
-        "winston": "^3.0.0"
+        "newrelic": ">=6.2.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -2547,9 +2546,9 @@
       "requires": {}
     },
     "@newrelic/winston-enricher": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/winston-enricher/-/winston-enricher-2.1.2.tgz",
-      "integrity": "sha512-9LVwFvGd0QwQbEbKO1VGx47saxF4abvWG69abIYAGPVOOPPZMtf13hFXwE/1/pT73AP6xntgn4bFwM4gZmg1NA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/winston-enricher/-/winston-enricher-3.0.0.tgz",
+      "integrity": "sha512-fb9FRMPufM+GrI3wjtAorpgi/wTRBabK6a6Hcknl5Db71YqjdU4lDsebCbPhOSNGadpANLcIHoSsZEqu8MUwXw==",
       "requires": {}
     },
     "@protobufjs/aspromise": {

--- a/log-generator/package.json
+++ b/log-generator/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@newrelic/pino-enricher": "^0.1.0",
-    "@newrelic/winston-enricher": "^2.1.2",
+    "@newrelic/winston-enricher": "^3.0.0",
     "faker": "^5.5.3",
     "newrelic": "^8.9.1",
     "pino": "^7.9.2",

--- a/logs-in-context/app/server.js
+++ b/logs-in-context/app/server.js
@@ -17,8 +17,8 @@ const start = async () => {
   const { PORT = 3000, HOST = 'localhost', WINSTON } = process.env
   let logger
   if (WINSTON) {
-    const nrWinston = require('@newrelic/winston-enricher')
     const winston = require('winston')
+    const nrWinston = require('@newrelic/winston-enricher')(winston)
     logger = winston.createLogger({
       levels: {
         fatal: 0,


### PR DESCRIPTION
This PR updates the example apps to use the latest version (v3.0.0) of `@newrelic/winston-enricher`.