### PR TITLE
Remove log enricher, rely on agent

### DIFF
--- a/log-generator/log-generator.js
+++ b/log-generator/log-generator.js
@@ -16,6 +16,7 @@ process.env.NEW_RELIC_APPLICATION_LOGGING_ENABLED = true
 process.env.NEW_RELIC_APPLICATION_LOGGING_FORWARDING_ENABLED = true
 process.env.NEW_RELIC_APPLICATION_LOGGING_METRICS_ENABLED = true
 process.env.NEW_RELIC_APPLICATION_LOGGING_FORWARDING_MAX_SAMPLES_STORED = 10000
+process.env.NEW_RELIC_APPLICATION_LOGGING_LOCAL_DECORATING_ENABLED = false
 
 const newrelic = require('newrelic')
 // we can't put a listener for 'errored'
@@ -109,7 +110,6 @@ function getLogger(logtype) {
   let logger
   if (logtype === 'winston') {
     const winston = require('winston')
-    const newrelicFormatter = require('@newrelic/winston-enricher')(winston)
     const { createLogger, format, transports } = winston
 
     logger = createLogger({
@@ -120,8 +120,7 @@ function getLogger(logtype) {
         }),
         format.errors({ stack: true }),
         format.splat(),
-        format.json(),
-        newrelicFormatter()
+        format.json()
       ),
       defaultMeta: { service: process.env.NEW_RELIC_APP_NAME },
       transports: [new transports.Console()]

--- a/log-generator/package-lock.json
+++ b/log-generator/package-lock.json
@@ -6,9 +6,8 @@
     "": {
       "dependencies": {
         "@newrelic/pino-enricher": "^0.1.0",
-        "@newrelic/winston-enricher": "^3.0.0",
         "faker": "^5.5.3",
-        "newrelic": "^8.9.1",
+        "newrelic": "^8.10.0",
         "pino": "^7.9.2",
         "winston": "^3.7.2",
         "yargs": "^17.4.0"
@@ -286,9 +285,9 @@
       }
     },
     "node_modules/@newrelic/native-metrics": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-7.1.2.tgz",
-      "integrity": "sha512-Ay0iLiwb/TIlbxxuWqxhrW1FxOSokKS09NKcRi1VXsMCMmvJiVhq6wvJcFvpoGLzvkTLLMFrJAHP0eJBKUpZfQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-8.0.0.tgz",
+      "integrity": "sha512-df/V1P6dxpX09PaA6Jx9pmkPbRrue5hDyRCc4w3bnqMbnybvwVwS+q1/QEPvjBPQJ5abTRlBcJ7UZ3sfGW1hzg==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -321,17 +320,6 @@
       },
       "peerDependencies": {
         "newrelic": ">=6.11.0"
-      }
-    },
-    "node_modules/@newrelic/winston-enricher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/winston-enricher/-/winston-enricher-3.0.0.tgz",
-      "integrity": "sha512-fb9FRMPufM+GrI3wjtAorpgi/wTRBabK6a6Hcknl5Db71YqjdU4lDsebCbPhOSNGadpANLcIHoSsZEqu8MUwXw==",
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "newrelic": ">=6.2.0"
       }
     },
     "node_modules/@protobufjs/aspromise": {
@@ -1298,9 +1286,9 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -1564,9 +1552,9 @@
       "peer": true
     },
     "node_modules/newrelic": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.9.1.tgz",
-      "integrity": "sha512-t11Maq7kCdn5DziSS84m9+OcTeWKHImk/942FC1/8gbcQwLrkiFLdAI6pRkSi+RXZ5JsnZ+iEiL4ungiEVO71A==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.10.0.tgz",
+      "integrity": "sha512-7gBtVsdblR074M262zuyMIrkOCIzJ+uJsmKrRfqkoqFos0ck/SpnahNSp+Q5LDiVq3Q+03G3sBVErK2yShv6iQ==",
       "dependencies": {
         "@grpc/grpc-js": "^1.5.5",
         "@grpc/proto-loader": "^0.6.9",
@@ -1589,7 +1577,7 @@
         "npm": ">=6.0.0"
       },
       "optionalDependencies": {
-        "@newrelic/native-metrics": "^7.1.1"
+        "@newrelic/native-metrics": "^8.0.0"
       }
     },
     "node_modules/on-exit-leak-free": {
@@ -2523,9 +2511,9 @@
       "requires": {}
     },
     "@newrelic/native-metrics": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-7.1.2.tgz",
-      "integrity": "sha512-Ay0iLiwb/TIlbxxuWqxhrW1FxOSokKS09NKcRi1VXsMCMmvJiVhq6wvJcFvpoGLzvkTLLMFrJAHP0eJBKUpZfQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/native-metrics/-/native-metrics-8.0.0.tgz",
+      "integrity": "sha512-df/V1P6dxpX09PaA6Jx9pmkPbRrue5hDyRCc4w3bnqMbnybvwVwS+q1/QEPvjBPQJ5abTRlBcJ7UZ3sfGW1hzg==",
       "optional": true,
       "requires": {
         "https-proxy-agent": "^5.0.0",
@@ -2543,12 +2531,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@newrelic/superagent/-/superagent-5.1.1.tgz",
       "integrity": "sha512-Bp2QtknriKHLKSfrBRyg4PjGJ8CCSkxYfZEDppOWmrGukJAP/9Vvr+ya0Mmj7SU8eIMMhaTvAnjvb2mVmX8wBw==",
-      "requires": {}
-    },
-    "@newrelic/winston-enricher": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/winston-enricher/-/winston-enricher-3.0.0.tgz",
-      "integrity": "sha512-fb9FRMPufM+GrI3wjtAorpgi/wTRBabK6a6Hcknl5Db71YqjdU4lDsebCbPhOSNGadpANLcIHoSsZEqu8MUwXw==",
       "requires": {}
     },
     "@protobufjs/aspromise": {
@@ -3323,9 +3305,9 @@
       "peer": true
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "requires": {
         "agent-base": "6",
         "debug": "4"
@@ -3544,15 +3526,15 @@
       "peer": true
     },
     "newrelic": {
-      "version": "8.9.1",
-      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.9.1.tgz",
-      "integrity": "sha512-t11Maq7kCdn5DziSS84m9+OcTeWKHImk/942FC1/8gbcQwLrkiFLdAI6pRkSi+RXZ5JsnZ+iEiL4ungiEVO71A==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-8.10.0.tgz",
+      "integrity": "sha512-7gBtVsdblR074M262zuyMIrkOCIzJ+uJsmKrRfqkoqFos0ck/SpnahNSp+Q5LDiVq3Q+03G3sBVErK2yShv6iQ==",
       "requires": {
         "@grpc/grpc-js": "^1.5.5",
         "@grpc/proto-loader": "^0.6.9",
         "@newrelic/aws-sdk": "^4.1.1",
         "@newrelic/koa": "^6.1.1",
-        "@newrelic/native-metrics": "^7.1.1",
+        "@newrelic/native-metrics": "^8.0.0",
         "@newrelic/superagent": "^5.1.0",
         "@tyriar/fibonacci-heap": "^2.0.7",
         "async": "^3.2.3",

--- a/log-generator/package.json
+++ b/log-generator/package.json
@@ -1,9 +1,8 @@
 {
   "dependencies": {
     "@newrelic/pino-enricher": "^0.1.0",
-    "@newrelic/winston-enricher": "^3.0.0",
     "faker": "^5.5.3",
-    "newrelic": "^8.9.1",
+    "newrelic": "^8.10.0",
     "pino": "^7.9.2",
     "winston": "^3.7.2",
     "yargs": "^17.4.0"


### PR DESCRIPTION
I removed the winston log enricher as this will be automatically done in agent now.  We were also missing local decorating env var. Until the new agent version is released to use this you'll have to link the agent

```sh
npm link # in main of agent
npm link newrelic # in this app
node log-generator.js # see logs getting fowarded with proper context info
```