### PR TITLE
updated the agent to be the released version and not a git sha

### DIFF
--- a/code-level-metrics/express/package-lock.json
+++ b/code-level-metrics/express/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "express": "^4.18.2",
-        "newrelic": "github:newrelic/node-newrelic#71c82960fa121e451728282caf7c389b95811754"
+        "newrelic": "^9.7.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -748,10 +748,9 @@
       }
     },
     "node_modules/newrelic": {
-      "version": "9.7.0",
-      "resolved": "git+ssh://git@github.com/newrelic/node-newrelic.git#71c82960fa121e451728282caf7c389b95811754",
-      "integrity": "sha512-zvoaeU1CsXgLRnlsLJZFdXXJOMbDBl6+Quo6RRVp1gjLx4qcKNu1sb8a2JfNyFvvhCSV+YVxL8dyyVQMI1n/Eg==",
-      "license": "Apache-2.0",
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.7.1.tgz",
+      "integrity": "sha512-qZpjOhb53kLyUIZevLW7/Wg7SNJ5l25bD/wTbQAr1ALuDNYVwOfaxYZopsshJ9qVib2ykIFCJVrTQsBJCGC0Fg==",
       "dependencies": {
         "@grpc/grpc-js": "^1.7.3",
         "@grpc/proto-loader": "^0.7.3",
@@ -1751,9 +1750,9 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
     "newrelic": {
-      "version": "git+ssh://git@github.com/newrelic/node-newrelic.git#71c82960fa121e451728282caf7c389b95811754",
-      "integrity": "sha512-zvoaeU1CsXgLRnlsLJZFdXXJOMbDBl6+Quo6RRVp1gjLx4qcKNu1sb8a2JfNyFvvhCSV+YVxL8dyyVQMI1n/Eg==",
-      "from": "newrelic@git://github.com/newrelic/node-newrelic.git#71c82960fa121e451728282caf7c389b95811754",
+      "version": "9.7.1",
+      "resolved": "https://registry.npmjs.org/newrelic/-/newrelic-9.7.1.tgz",
+      "integrity": "sha512-qZpjOhb53kLyUIZevLW7/Wg7SNJ5l25bD/wTbQAr1ALuDNYVwOfaxYZopsshJ9qVib2ykIFCJVrTQsBJCGC0Fg==",
       "requires": {
         "@contrast/fn-inspect": "^3.3.0",
         "@grpc/grpc-js": "^1.7.3",

--- a/code-level-metrics/express/package.json
+++ b/code-level-metrics/express/package.json
@@ -10,6 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "express": "^4.18.2",
-    "newrelic": "github:newrelic/node-newrelic#71c82960fa121e451728282caf7c389b95811754"
+    "newrelic": "^9.7.1"
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
The sample app for CLM referenced a git SHA.  We released the agent with the initial CLM support so I updated the app to reflect this.
