### PR TITLE
messaging-app: update links to remove docs/ path component

### DIFF
--- a/messaging-app/README.md
+++ b/messaging-app/README.md
@@ -1,6 +1,6 @@
 # Example instrumentation of a messaging application
 
-This is an example app that uses the `newrelic.instrumentMessages` [API function](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentMessages) and associated [messaging shim API](https://newrelic.github.io/node-newrelic/docs/MessageShim.html) to instrument a toy messaging library called Nifty Messages. This sample instrumentation is an implementation of the [New Relic messaging instrumentation tutorial](http://newrelic.github.io/node-newrelic/docs/tutorial-Messaging-Simple.html).
+This is an example app that uses the `newrelic.instrumentMessages` [API function](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentMessages) and associated [messaging shim API](https://newrelic.github.io/node-newrelic/MessageShim.html) to instrument a toy messaging library called Nifty Messages. This sample instrumentation is an implementation of the [New Relic messaging instrumentation tutorial](http://newrelic.github.io/node-newrelic/tutorial-Messaging-Simple.html).
 
 ## Getting started
 
@@ -99,11 +99,11 @@ The application consists of the following files.
 * [`instrumentation.js`](./instrumentation.js): all of the New Relic instrumentation is in here. The `npm start` command loads this module first.
 * [`newrelic.js`](./newrelic.js): a basic, sample New Relic configuration.
 
-The instrumentation in `instrumentation.js` makes use of [`instrumentMessages`](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentMessages) and three relevant functions of the [messaging shim API](https://newrelic.github.io/node-newrelic/docs/MessageShim.html):
+The instrumentation in `instrumentation.js` makes use of [`instrumentMessages`](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/api-guides/nodejs-agent-api/#instrumentMessages) and three relevant functions of the [messaging shim API](https://newrelic.github.io/node-newrelic/MessageShim.html):
 
-* [`recordProduce`](https://newrelic.github.io/node-newrelic/docs/MessageShim.html#recordProduce)
-* [`recordConsume`](https://newrelic.github.io/node-newrelic/docs/MessageShim.html#recordConsume)
-* [`recordSubscribedConsume`](https://newrelic.github.io/node-newrelic/docs/MessageShim.html#recordSubscribedConsume)
+* [`recordProduce`](https://newrelic.github.io/node-newrelic/MessageShim.html#recordProduce)
+* [`recordConsume`](https://newrelic.github.io/node-newrelic/MessageShim.html#recordConsume)
+* [`recordSubscribedConsume`](https://newrelic.github.io/node-newrelic/MessageShim.html#recordSubscribedConsume)
 
 ## Additional Configuration
 If you are a New Relic employee and wanting to testing on a staging environment, add the following to the `npm start` command:


### PR DESCRIPTION
We changed the API docs, gotta change everything that linked to them.
