### PR TITLE
fix: add log file exclusion to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 newrelic_agent.log
 .idea
 dist
+.log

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ node_modules
 newrelic_agent.log
 .idea
 dist
-.log
+**/*.log


### PR DESCRIPTION
prevent log files from being accidentally added