### PR TITLE
chore: updated sample ESM app to reflect the upcoming method of instrumenting ESM

### DIFF
--- a/esm-app/custom-instrumentation/index.js
+++ b/esm-app/custom-instrumentation/index.js
@@ -1,6 +1,2 @@
-import parseJsonInstrumentation from './parse-json.js' 
-import normalizeUrlInstrumentation from './normalize-url.js'
-
-parseJsonInstrumentation()
-normalizeUrlInstrumentation()
-
+import './parse-json.js' 
+import './normalize-url.js'

--- a/esm-app/custom-instrumentation/normalize-url.js
+++ b/esm-app/custom-instrumentation/normalize-url.js
@@ -1,14 +1,12 @@
 import newrelic from 'newrelic'
 
-export default function() {
-  newrelic.instrument('normalize-url', function(shim, normalizeUrl, modName) {
-    shim.wrap(normalizeUrl, 'default', function wrapNormalizeUrl(shim, orig) {
-      return function wrappedNormalizeUrl() {
-        // call original normalizeUrl function and get result
-        const result = orig.apply(this, arguments)
-        // append instrumented to the normalized url
-        return `${result}/instrumented`
-      }
-    })
+newrelic.instrument({ moduleName: 'normalize-url', isEsm: true, onRequire: function(shim, normalizeUrl, modName) {
+  shim.wrap(normalizeUrl, 'default', function wrapNormalizeUrl(shim, orig) {
+    return function wrappedNormalizeUrl() {
+      // call original normalizeUrl function and get result
+      const result = orig.apply(this, arguments)
+      // append instrumented to the normalized url
+      return `${result}/instrumented`
+    }
   })
-}
+}})

--- a/esm-app/custom-instrumentation/parse-json.js
+++ b/esm-app/custom-instrumentation/parse-json.js
@@ -1,14 +1,12 @@
 import newrelic from 'newrelic'
-export default function() {
-  newrelic.instrument('parse-json', function(shim, parseJson, modName) {
-    shim.wrap(parseJson, 'default', function wrapParseJson(shim, orig) {
-      return function wrappedParsedJson() {
-        // call original parseJson function and get result
-        const result = orig.apply(this, arguments)
-        // apppend a key of `instrumented`
-        result.instrumented = true
-        return result
-      }
-    })
+newrelic.instrument({ moduleName: 'parse-json', isEsm: true, onRequire: function(shim, parseJson, modName) {
+  shim.wrap(parseJson, 'default', function wrapParseJson(shim, orig) {
+    return function wrappedParsedJson() {
+      // call original parseJson function and get result
+      const result = orig.apply(this, arguments)
+      // apppend a key of `instrumented`
+      result.instrumented = true
+      return result
+    }
   })
-}
+}})

--- a/esm-app/index.js
+++ b/esm-app/index.js
@@ -1,3 +1,4 @@
+import './custom-instrumentation/index.js'
 import express from 'express'
 const { PORT = '3000', HOST = 'localhost' } = process.env
 import parseJson from 'parse-json'

--- a/esm-app/newrelic.cjs
+++ b/esm-app/newrelic.cjs
@@ -22,11 +22,6 @@ exports.config = {
      */
     level: 'info'
   },
-  api: {
-    esm: {
-      custom_instrumentation_entrypoint: './custom-instrumentation/index.js'
-    }
-  },
   /**
    * When true, all request headers except for those listed in attributes.exclude
    * will be captured for all traces, unless otherwise specified in a destination's

--- a/esm-app/package.json
+++ b/esm-app/package.json
@@ -5,8 +5,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "node --experimental-loader newrelic/esm-loader.mjs index.js",
-    "debug": "node --inspect-brk --experimental-loader newrelic/esm-loader.mjs index.js",
+    "start": "node --experimental-loader newrelic/esm-loader.mjs -r newrelic index.js",
+    "debug": "node --inspect-brk --experimental-loader newrelic/esm-loader.mjs -r newrelic index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

## Links

## Details
In https://github.com/newrelic/node-newrelic/pull/1760 we are changing how to instrument ESM applications. This PR updates our sample app to show a working ESM app with instrumentation.

The overall highlights are:
 * you must use both a loader and -r to load agent. so `--loader newrelic/esm-loader.mjs -r newrelic`.
 * custom esm instrumentation is no longer config based but instead must provide `isEsm: true` when calling the API to instrument.


To test this out:
 * `npm link newrelic` assuming you're in https://github.com/newrelic/node-newrelic/pull/1760 branch.
 * `npm ci && npm link newrelic` in this branch.
 * `npm start`
 * `curl http://localhost:3000/instrumentation-example`

You should see ```{"key":"value","instrumented":true,"url":"http://example.com/instrumented"}``` as response.
