### PR TITLE
fix: Incorrect object used for logging in recordSubscribedConsume

### DIFF
--- a/custom-instrumentation/instrument-messages/instrumentation.js
+++ b/custom-instrumentation/instrument-messages/instrumentation.js
@@ -86,7 +86,7 @@ newrelic.instrumentMessages({ absolutePath: niftyPath, moduleName: 'nifty-messag
     // only the the consume calls made because a subscription was made
     // earlier.
     messageHandler(shim, consumer, name, args) {
-      const msg = args[0]
+      const msg = consumer[0]
       console.log(`[NEWRELIC] subscribe on queue ${msg.queueName} returned a message: '${msg.msg}'`)
       return {
         destinationName: msg.queueName,


### PR DESCRIPTION
In this commit we are fixing incorrect object used for logging in recordSubscribedConsume which is part of instrumentation. Due to incorrect object used, publish is completely broken as soon as we subscribe.

Test Cases:
1. PASS - Verify that we are able to publish messages even after subscribing.
