### PR TITLE
fix: Updated messaging example instrumentation file

### DIFF
--- a/custom-instrumentation/instrument-messages/instrumentation.js
+++ b/custom-instrumentation/instrument-messages/instrumentation.js
@@ -85,14 +85,13 @@ function instrumentNiftyMessages(shim, messages, moduleName) {
   shim.recordConsume(Client.prototype, 'getMessage', new shim.specs.MessageSpec({
     destinationName: shim.FIRST,
     callback: shim.LAST,
-    after({ args }) {
-      const [err, msg] = args
-      if (msg) {
+    after({ result, error }) {
+      if (result) {
         console.log(
-          `[NEWRELIC] getMessage on queue ${msg.queueName} returned a message: '${msg.msg}'`
+          `[NEWRELIC] getMessage on queue ${result.queueName} returned a message: '${result.msg}'`
         )
         // misc key/value parameters can be recorded as a part of the trace segment
-        const params = { message: msg.msg, queueName: msg.queueName }
+        const params = { message: result.msg, queueName: result.queueName }
 
         return {
           parameters: params
@@ -101,7 +100,7 @@ function instrumentNiftyMessages(shim, messages, moduleName) {
 
       console.log('[NEWRELIC] getMessage returned no message')
       return {
-        parameters: { err }
+        parameters: { err: error }
       }
     }
   }))

--- a/custom-instrumentation/instrument-messages/package.json
+++ b/custom-instrumentation/instrument-messages/package.json
@@ -12,7 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "express": "^4.19.2",
-    "newrelic": "^12.0.0"
+    "newrelic": "^12.5.0"
   },
   "devDependencies": {
     "@newrelic/eslint-config": "^0.2.0"


### PR DESCRIPTION
The agent shim was updated, and the example in `custom-instrumentation/instrument-messages/` was no longer compatible. This updates the instrumentation file and the agent version. 