### PR TITLE
feat: GCP PubSub example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
-newrelic_agent.log
+*.log
 .idea
 dist
 **/*.log

--- a/gcp-pubsub/README.md
+++ b/gcp-pubsub/README.md
@@ -23,6 +23,8 @@ npm run subscribe # Start subscriber
 npm run publish # Run publisher a few times
 ```
 
+
+
 ## Exploring Telemetry
 
 More to come later...

--- a/gcp-pubsub/README.md
+++ b/gcp-pubsub/README.md
@@ -6,7 +6,7 @@ This is an example app that uses the [New Relic agent](https://github.com/newrel
 
 ### Setup GCP PubSub
 
-In the [PubSub Getting Started guide](https://cloud.google.com/pubsub/docs/publish-receive-messages-client-library#before-you-begin), follow the steps in the "Before you begin" and "Create a topic and subscription" sections. `my-topic` is the default topic name and `my-sub` is the default subscription name (matches the guide), but this can be changed in `env-p.sample` and `env-s.sample` respectively.
+In the [PubSub Getting Started guide](https://web.archive.org/web/20250401131419/https://cloud.google.com/pubsub/docs/publish-receive-messages-client-library#before-you-begin), follow the steps in the "Before you begin" and "Create a topic and subscription" sections. `my-topic` is the default topic name and `my-sub` is the default subscription name (matches the guide), but this can be changed in `env-p.sample` and `env-s.sample` respectively.
 
 ### Run Example
 

--- a/gcp-pubsub/README.md
+++ b/gcp-pubsub/README.md
@@ -1,0 +1,28 @@
+# OpenTelemetry Example PubSub App
+
+This is an example app that uses the [New Relic agent](https://github.com/newrelic/node-newrelic) in the opentelemetry bridge mode to instrument GCP PubSub.
+
+## Setup
+
+### Setup GCP PubSub
+
+In the [PubSub Getting Started guide](https://cloud.google.com/pubsub/docs/publish-receive-messages-client-library#before-you-begin), follow the steps in the "Before you begin" and "Create a topic and subscription" sections. Make sure to use `my-topic` for the topic name and `my-sub` for the subscription name, so it matches the example app code.
+
+### Run Example
+
+Requirements:
+
++ Node.js >= 20.6.0
+
+```sh
+npm install
+cp env-p.sample .env-p # Publisher env vars
+cp env-s.sample .env-s # Subscriber env vars
+# Fill out `NEW_RELIC_LICENSE_KEY` in .env-p and .env-s
+npm run subscribe # Start subscriber
+npm run publish # Run publisher a few times
+```
+
+## Exploring Telemetry
+
+More to come later...

--- a/gcp-pubsub/README.md
+++ b/gcp-pubsub/README.md
@@ -6,7 +6,7 @@ This is an example app that uses the [New Relic agent](https://github.com/newrel
 
 ### Setup GCP PubSub
 
-In the [PubSub Getting Started guide](https://cloud.google.com/pubsub/docs/publish-receive-messages-client-library#before-you-begin), follow the steps in the "Before you begin" and "Create a topic and subscription" sections. Make sure to use `my-topic` for the topic name and `my-sub` for the subscription name, so it matches the example app code.
+In the [PubSub Getting Started guide](https://cloud.google.com/pubsub/docs/publish-receive-messages-client-library#before-you-begin), follow the steps in the "Before you begin" and "Create a topic and subscription" sections. `my-topic` is the default topic name and `my-sub` is the default subscription name (matches the guide), but this can be changed in `env-p.sample` and `env-s.sample` respectively.
 
 ### Run Example
 
@@ -22,8 +22,6 @@ cp env-s.sample .env-s # Subscriber env vars
 npm run subscribe # Start subscriber
 npm run publish # Run publisher a few times
 ```
-
-
 
 ## Exploring Telemetry
 

--- a/gcp-pubsub/env-p.sample
+++ b/gcp-pubsub/env-p.sample
@@ -4,3 +4,4 @@ NEW_RELIC_LICENSE_KEY=
 NEW_RELIC_HOST=staging-collector.newrelic.com
 NEW_RELIC_APP_NAME=gcp-pubsub-publisher
 NEW_RELIC_LOG=publisher.log
+GCP_TOPIC=my-topic

--- a/gcp-pubsub/env-p.sample
+++ b/gcp-pubsub/env-p.sample
@@ -1,7 +1,7 @@
 NEW_RELIC_LICENSE_KEY=
 
 # For NR devs using staging
-NEW_RELIC_HOST=staging-collector.newrelic.com
+# NEW_RELIC_HOST=staging-collector.newrelic.com
 NEW_RELIC_APP_NAME=gcp-pubsub-publisher
 NEW_RELIC_LOG=publisher.log
 GCP_TOPIC=my-topic

--- a/gcp-pubsub/env-p.sample
+++ b/gcp-pubsub/env-p.sample
@@ -1,0 +1,6 @@
+NEW_RELIC_LICENSE_KEY=
+
+# For NR devs using staging
+NEW_RELIC_HOST=staging-collector.newrelic.com
+NEW_RELIC_APP_NAME=gcp-pubsub-publisher
+NEW_RELIC_LOG=publisher.log

--- a/gcp-pubsub/env-s.sample
+++ b/gcp-pubsub/env-s.sample
@@ -1,7 +1,7 @@
 NEW_RELIC_LICENSE_KEY=
 
 # For NR devs using staging
-NEW_RELIC_HOST=staging-collector.newrelic.com
+# NEW_RELIC_HOST=staging-collector.newrelic.com
 NEW_RELIC_APP_NAME=gcp-pubsub-subscriber
 NEW_RELIC_LOG=subscriber.log
 GCP_SUBSCRIPTION=my-sub

--- a/gcp-pubsub/env-s.sample
+++ b/gcp-pubsub/env-s.sample
@@ -4,3 +4,4 @@ NEW_RELIC_LICENSE_KEY=
 NEW_RELIC_HOST=staging-collector.newrelic.com
 NEW_RELIC_APP_NAME=gcp-pubsub-subscriber
 NEW_RELIC_LOG=subscriber.log
+GCP_SUBSCRIPTION=my-sub

--- a/gcp-pubsub/env-s.sample
+++ b/gcp-pubsub/env-s.sample
@@ -1,0 +1,6 @@
+NEW_RELIC_LICENSE_KEY=
+
+# For NR devs using staging
+NEW_RELIC_HOST=staging-collector.newrelic.com
+NEW_RELIC_APP_NAME=gcp-pubsub-subscriber
+NEW_RELIC_LOG=subscriber.log

--- a/gcp-pubsub/newrelic.js
+++ b/gcp-pubsub/newrelic.js
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+/**
+ * New Relic agent configuration.
+ *
+ * See lib/config/default.js in the agent distribution for a more complete
+ * description of configuration variables and their potential values. */
+
+exports.config = {
+    logging: {
+        /**
+         * Level at which to log. 'trace' is most useful to New Relic when diagnosing
+         * issues with the agent, 'info' and higher will impose the least overhead on
+         * production applications.
+         */
+        level: 'trace'
+    },
+    /**
+     * When true, all request headers except for those listed in attributes.exclude
+     * will be captured for all traces, unless otherwise specified in a destination's
+     * attributes include/exclude lists.
+     */
+    allow_all_headers: true,
+    /**
+     * The below is required to enable the OpenTelemetry bridge.
+     */
+    feature_flag: {
+        opentelemetry_bridge: true
+    },
+    attributes: {
+        /**
+         * Prefix of attributes to exclude from all destinations. Allows * as wildcard
+         * at end.
+         *
+         * NOTE: If excluding headers, they must be in camelCase form to be filtered.
+         *
+         * @env NEW_RELIC_ATTRIBUTES_EXCLUDE
+         */
+        exclude: [
+            'request.headers.cookie',
+            'request.headers.authorization',
+            'request.headers.proxyAuthorization',
+            'request.headers.setCookie*',
+            'request.headers.x*',
+            'response.headers.cookie',
+            'response.headers.authorization',
+            'response.headers.proxyAuthorization',
+            'response.headers.setCookie*',
+            'response.headers.x*'
+        ]
+    }
+}

--- a/gcp-pubsub/package.json
+++ b/gcp-pubsub/package.json
@@ -14,6 +14,6 @@
   },
   "dependencies": {
     "@google-cloud/pubsub": "^4.10.0",
-    "newrelic": "^12.16.0"
+    "newrelic": "^12.17.0"
   }
 }

--- a/gcp-pubsub/package.json
+++ b/gcp-pubsub/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "gcp-pubsub-test",
+  "version": "0.0.1",
+  "description": "An example PubSub app.",
+  "main": "index.js",
+  "scripts": {
+    "subscribe": "node -r newrelic --env-file .env-s ./subscriber.js",
+    "publish": "node -r newrelic --env-file .env-p ./publisher.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "engines": {
+    "node": ">=20.6.0"
+  },
+  "dependencies": {
+    "@google-cloud/pubsub": "^4.10.0",
+    "newrelic": "^12.16.0"
+  }
+}

--- a/gcp-pubsub/publisher.js
+++ b/gcp-pubsub/publisher.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const newrelic = require('newrelic')
+const { PubSub } = require('@google-cloud/pubsub')
+
+async function publishMessage() {
+    try {
+        // Assumes Google Cloud credentials are set up via this example:
+        // https://cloud.google.com/pubsub/docs/publish-receive-messages-client-library#node.js
+        const publisher = new PubSub({ enableOpenTelemetryTracing: true })
+        // Create a topic, then publish a message to it
+        const topicName = 'my-topic'
+        const topic = publisher.topic(topicName)
+        const messageId = await topic.publishMessage({ data: Buffer.from('Hello, world!') })
+        console.log(`Message ${messageId} published.`)
+    } catch (err) {
+        console.log('Could not publish message:\n', err)
+    }
+}
+
+async function main() {
+    if (newrelic.agent.collector.isConnected() === false) {
+        await new Promise((resolve) => {
+            newrelic.agent.on('connected', resolve)
+        })
+    }
+
+    newrelic.startBackgroundTransaction('publish-message', async function handleTransaction() {
+        const txn = newrelic.getTransaction()
+        await publishMessage()
+        txn.end()
+        newrelic.shutdown({ collectPendingData: true }, () => process.exit(0))
+    });
+}
+
+main()

--- a/gcp-pubsub/publisher.js
+++ b/gcp-pubsub/publisher.js
@@ -30,7 +30,7 @@ async function main() {
         await publishMessage()
         txn.end()
         newrelic.shutdown({ collectPendingData: true }, () => process.exit(0))
-    });
+    })
 }
 
 main()

--- a/gcp-pubsub/publisher.js
+++ b/gcp-pubsub/publisher.js
@@ -9,7 +9,7 @@ async function publishMessage() {
         // https://cloud.google.com/pubsub/docs/publish-receive-messages-client-library#node.js
         const publisher = new PubSub({ enableOpenTelemetryTracing: true })
         // Create a topic, then publish a message to it
-        const topicName = 'my-topic'
+        const topicName = process.env.GCP_TOPIC
         const topic = publisher.topic(topicName)
         const messageId = await topic.publishMessage({ data: Buffer.from('Hello, world!') })
         console.log(`Message ${messageId} published.`)

--- a/gcp-pubsub/subscriber.js
+++ b/gcp-pubsub/subscriber.js
@@ -7,14 +7,12 @@ async function startSubscriber() {
     // Assumes Google Cloud credentials are set up via this example:
     // https://cloud.google.com/pubsub/docs/publish-receive-messages-client-library#node.js
     const subscriber = new PubSub({ enableOpenTelemetryTracing: true })
-    const subscriptionName = 'my-sub'
+    const subscriptionName = process.env.GCP_SUBSCRIPTION
     const subscription = subscriber.subscription(subscriptionName)
     console.log(`Listening for messages on ${subscriptionName}`)
     subscription.on('message', message => {
-        newrelic.startBackgroundTransaction('receive-message', async function handleTransaction() {
-            console.log(`Received message: ${message.data}`)
-            message.ack()
-        })
+        console.log(`Received message: ${message.data}`)
+        message.ack()
     })
 }
 

--- a/gcp-pubsub/subscriber.js
+++ b/gcp-pubsub/subscriber.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const newrelic = require('newrelic')
+const { PubSub } = require('@google-cloud/pubsub')
+
+async function startSubscriber() {
+    // Assumes Google Cloud credentials are set up via this example:
+    // https://cloud.google.com/pubsub/docs/publish-receive-messages-client-library#node.js
+    const subscriber = new PubSub({ enableOpenTelemetryTracing: true })
+    const subscriptionName = 'my-sub'
+    const subscription = subscriber.subscription(subscriptionName)
+    console.log(`Listening for messages on ${subscriptionName}`)
+    subscription.on('message', message => {
+        // TODO: wrap in transaction?
+        console.log(`Received message: ${message.data}`)
+        message.ack()
+    })
+}
+
+async function main() {
+    if (newrelic.agent.collector.isConnected() === false) {
+        await new Promise((resolve) => {
+            newrelic.agent.on('connected', resolve)
+        })
+    }
+    await startSubscriber()
+}
+
+main()

--- a/gcp-pubsub/subscriber.js
+++ b/gcp-pubsub/subscriber.js
@@ -11,9 +11,10 @@ async function startSubscriber() {
     const subscription = subscriber.subscription(subscriptionName)
     console.log(`Listening for messages on ${subscriptionName}`)
     subscription.on('message', message => {
-        // TODO: wrap in transaction?
-        console.log(`Received message: ${message.data}`)
-        message.ack()
+        newrelic.startBackgroundTransaction('receive-message', async function handleTransaction() {
+            console.log(`Received message: ${message.data}`)
+            message.ack()
+        })
     })
 }
 

--- a/opentelemetry-example/env.sample
+++ b/opentelemetry-example/env.sample
@@ -1,5 +1,5 @@
 NEW_RELIC_LICENSE_KEY=
 
 # For NR devs using staging
-#NEW_RELIC_HOST=staging-collector.newrelic.com
+# NEW_RELIC_HOST=staging-collector.newrelic.com
 NEW_RELIC_APP_NAME=otel-example

--- a/opentelemetry-example/env2.sample
+++ b/opentelemetry-example/env2.sample
@@ -1,6 +1,6 @@
 NEW_RELIC_LICENSE_KEY=
 
 # For NR devs using staging
-#NEW_RELIC_HOST=staging-collector.newrelic.com
+# NEW_RELIC_HOST=staging-collector.newrelic.com
 NEW_RELIC_APP_NAME=otel-example-2
 PORT=3001

--- a/opentelemetry-messaging/env-c.sample
+++ b/opentelemetry-messaging/env-c.sample
@@ -1,6 +1,6 @@
 NEW_RELIC_LICENSE_KEY=
 
 # For NR devs using staging
-NEW_RELIC_HOST=staging-collector.newrelic.com
+# NEW_RELIC_HOST=staging-collector.newrelic.com
 NEW_RELIC_APP_NAME=opentelemetry-consumer
 NEW_RELIC_LOG=consumer.log

--- a/opentelemetry-messaging/env-p.sample
+++ b/opentelemetry-messaging/env-p.sample
@@ -1,6 +1,6 @@
 NEW_RELIC_LICENSE_KEY=
 
 # For NR devs using staging
-NEW_RELIC_HOST=staging-collector.newrelic.com
+# NEW_RELIC_HOST=staging-collector.newrelic.com
 NEW_RELIC_APP_NAME=opentelemetry-producer
 NEW_RELIC_LOG=producer.log


### PR DESCRIPTION
This is an example app to show how a library that natively supports OTel (e.g. `@google-cloud/pubsub`) can be easily instrumented with our agent's OTel bridge.

This PR resolves #319.