### PR TITLE
chore: Updated scripts for next.js app to use `--require` instead of `-r` to workaround a bug in Next.js CLI

### DIFF
--- a/nextjs/nextjs-app-router/package.json
+++ b/nextjs/nextjs-app-router/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
-    "dev": "NODE_OPTIONS='-r dotenv/config --loader newrelic/esm-loader.mjs -r newrelic' next dev",
-    "build": "NODE_OPTIONS='-r dotenv/config' next build",
-    "start": "NODE_OPTIONS='-r dotenv/config --loader newrelic/esm-loader.mjs -r newrelic' next start",
+    "dev": "NODE_OPTIONS='--require dotenv/config --loader newrelic/esm-loader.mjs --require newrelic' next dev",
+    "build": "NODE_OPTIONS='--require dotenv/config' next build",
+    "start": "NODE_OPTIONS='--require dotenv/config --loader newrelic/esm-loader.mjs --require newrelic' next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/nextjs/nextjs-legacy/package.json
+++ b/nextjs/nextjs-legacy/package.json
@@ -1,8 +1,8 @@
 {
   "scripts": {
-    "dev": "NODE_OPTIONS='-r dotenv/config --loader newrelic/esm-loader.mjs -r newrelic' next dev",
-    "build": "NODE_OPTIONS='-r dotenv/config' next build",
-    "start": "NODE_OPTIONS='-r dotenv/config --loader newrelic/esm-loader.mjs -r newrelic' next start",
+    "dev": "NODE_OPTIONS='--require dotenv/config --loader newrelic/esm-loader.mjs --require newrelic' next dev",
+    "build": "NODE_OPTIONS='--require dotenv/config' next build",
+    "start": "NODE_OPTIONS='--require dotenv/config --loader newrelic/esm-loader.mjs --require newrelic' next start",
     "lint": "next lint"
   },
   "dependencies": {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

Next.js CLI messes with the keys in `NODE_OPTIONS`, by prepending `--` to all even when some are only valid with `-`.  Instead of continuning to explain this with our community this PR updates the npm scripts in next.js apps to use `--require`.  
