### PR TITLE
feat: Updated mock 8T server to allow for failures and customize reconnect

### DIFF
--- a/mock-infinite-tracing-server/README.md
+++ b/mock-infinite-tracing-server/README.md
@@ -19,20 +19,18 @@ Once the gPRC server is started, you can use it in an example application and se
 
 ```js
 exports.config = {
-  license_key: <your-license-key>,
-  infinite_tracing: {
-    trace_observer: {
-      host: 'localhost',
-      port: 50051
+    license_key: <your-license-key>,
+    infinite_tracing: {
+        trace_observer: {
+            host: 'localhost',
+            port: 50051,
+            insecure: true
+        }
     }
-  }
 }
 ```
 
 As you use the application the mock gPRC server will log to console the number of spans seen.
-
-**Note**: You have to swap out the credentials in agent with insecure creds [here](https://github.com/newrelic/node-newrelic/blob/main/lib/grpc/connection.js#L380)
-
 
 ## Testing errors
 You can have the mock server respond with an error every n calls.  The agent has client retries built in and this can verify it is working. Below is an example that fails every 10th call:

--- a/mock-infinite-tracing-server/README.md
+++ b/mock-infinite-tracing-server/README.md
@@ -22,10 +22,21 @@ exports.config = {
   license_key: <your-license-key>,
   infinite_tracing: {
     trace_observer: {
-      host: 'localhost:50051
+      host: 'localhost',
+      port: 50051
     }
   }
 }
 ```
 
 As you use the application the mock gPRC server will log to console the number of spans seen.
+
+**Note**: You have to swap out the credentials in agent with insecure creds [here](https://github.com/newrelic/node-newrelic/blob/main/lib/grpc/connection.js#L380)
+
+
+## Testing errors
+You can have the mock server respond with an error every n calls.  The agent has client retries built in and this can verify it is working. Below is an example that fails every 10th call:
+
+```sh
+NR_FAILS=true NR_FAIL_N_CALLS=10 node index.js
+```

--- a/mock-infinite-tracing-server/index.js
+++ b/mock-infinite-tracing-server/index.js
@@ -11,57 +11,48 @@ const pkgDef = protoLoader.loadSync('./inifinite-trace.proto', {
 const proto = grpc.loadPackageDefinition(pkgDef)
 const traceApi = proto.com.newrelic.trace.v1
 const failCount = process.env.NR_FAIL_N_CALLS ?? 10
-const fails = process.env.NR_FAILS
+const fails = process.env.NR_FAILS ?? false
 const serverTimeout = process.env.NR_TIMEOUT ?? 30000
 let calls = 0
-
-// Simply just reflect back the data getting passed from client stream
 let spans = 0
-const infiniteTraceServer = {
-  recordSpan: function(call, cb) {
-    console.log('recordSpan')
-    call.on('data', () => {
-      if (fails && calls % failCount === 0) {
-        calls++
-        call.emit('error', { code: 14, message: 'bob-test'})
-        return
-      }
-      calls++
-      spans++
-      call.pendingStatus = { code: 0 , details: 'OK'}
-      console.log(`processed ${spans} spans thus far`)
-      call.write({ messages_seen: 1 })
-    })
-    
-    setTimeout(() => {
-      console.log('calling server stream end')
-      call.end()
-    }, serverTimeout)
-  },
-  recordSpanBatch: function(call, cb) {
-    console.log('recordSpanBatch')
-    call.on('data', (clientStream) => {
-      if (fails && calls % failCount === 0) {
-        calls++
-        console.log('emit error')
-        call.emit('error', {
-          code: 14,
-          message: 'bob-test'
-        })
-        return
-      }
-      calls++
-      call.pendingStatus = { code: 0 , details: 'OK'}
-      spans += clientStream.spans.length
-      console.log(`processed ${spans} spans thus far`)
-      call.write({ messages_seen: clientStream.spans.length })
-    })
+const errorResponse = { code: 14, message: 'intentional failure'}
+const okResponse = { code: 0, message: 'OK'}
 
-    setTimeout(() => {
-      console.log('calling server stream end')
-      call.end()
-    }, serverTimeout)
-  }
+/**
+ * Handles processing of spans. If `NR_FAILS` is true
+ * it'll fail every 10 calls of value of `NR_FAIL_N_CALLS`.
+ * It keeps a tally of total spans processed during the life of the process.
+ *
+ * It also simulates the real server by ending the stream every 30 seconds or
+ * configurable via `NR_TIMEOUT`.
+ */
+function abstractHandler(method, call) {
+  console.log(method)
+  call.on('data', (clientStream) => {
+    if (fails && calls % failCount === 0) {
+      calls++
+      console.log('emit error')
+      call.emit('error', errorResponse) 
+      return
+    }
+    calls++
+    const spansSeen = clientStream?.spans?.length ?? 1
+    spans += spansSeen 
+    // Reset the pendingStatus so subsequent calls are successful
+    call.pendingStatus = okResponse 
+    console.log(`processed ${spans} spans.`)
+    call.write({ messages_seen: spansSeen })
+  })
+  
+  setTimeout(() => {
+    console.log('ending server stream')
+    call.end()
+  }, serverTimeout)
+}
+
+const infiniteTraceServer = {
+  recordSpan: abstractHandler.bind(null, 'recordSpan'),
+  recordSpanBatch: abstractHandler.bind(null, 'recordSpanBatch')
 }
 
 async function connect() {

--- a/mock-infinite-tracing-server/package.json
+++ b/mock-infinite-tracing-server/package.json
@@ -4,12 +4,12 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "node index.js"
   },
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@grpc/grpc-js": "^1.8.14",
-    "@grpc/proto-loader": "^0.7.6"
+    "@grpc/grpc-js": "^1.13.2",
+    "@grpc/proto-loader": "^0.7.13"
   }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

This PR adds support for emitting errors on server as well as reconnecting to mimic the production 8T ingest service.  I also updated the README to properly explain all of this and how to work with an agent.
