### PR TITLE
chore: Added notes on instrumenting NextJs client pages and Turbopack

### DIFF
--- a/nextjs/nextjs-app-router/app/user/edit/[id]/page.js
+++ b/nextjs/nextjs-app-router/app/user/edit/[id]/page.js
@@ -1,4 +1,6 @@
 'use client'
+// If instrumenting client pages, do not import or require the New Relic APM agent. 
+// Instead, use the New Relic Browser agent to instrument client pages. See below. 
 
 // See https://nextjs.org/docs/pages/building-your-application/data-fetching/client-side#client-side-data-fetching-with-useeffect
 // See https://react.dev/reference/react/useState
@@ -24,6 +26,11 @@ export default function Page({ params }) {
 
   if (isLoading === true) return <p>Loading...</p>
   if (!user) return notFound()
+
+  // Instrumenting client pages:
+  // Using New Relic API methods in client pages will require the New Relic Browser Agent, 
+  // which is available on the global `window` object:
+  // window.newrelic.setCustomAttribute("customAttribute", 'custom attribute value')
 
   async function onSubmit(event) {
     event.preventDefault()

--- a/nextjs/nextjs-app-router/next.config.js
+++ b/nextjs/nextjs-app-router/next.config.js
@@ -3,13 +3,19 @@
 const nrExternals = require('newrelic/load-externals')
 
 module.exports = {
+  // For use with Next 14 and earlier:
   experimental: {
     // Without this setting, the Next.js compilation step will routinely
     // try to import files such as `LICENSE` from the `newrelic` module.
     // See https://nextjs.org/docs/app/api-reference/next-config-js/serverComponentsExternalPackages.
     serverComponentsExternalPackages: ['newrelic']
   },
-
+  
+  // In Next15, server external packages are no longer experimental, this property is renamed serverExternalPackages. 
+  // `newrelic` is already automatically opted out of bundling, so does not need to be defined here. 
+  // See https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages
+  // serverExternalPackages: ['otherDependency']
+  
   // In order for newrelic to effectively instrument a Next.js application,
   // the modules that newrelic supports should not be mangled by webpack. Thus,
   // we need to "externalize" all of the modules that newrelic supports.
@@ -17,4 +23,12 @@ module.exports = {
     nrExternals(config)
     return config
   }
+  
+  // Turbopack: NextJs offers the Turbopack incremental bundler as a replacement for webpack. 
+  // Its configuration requires a minimal change: 
+  //
+  // turbopack: (config) => {
+  //   nrExternals(config)
+  //   return config
+  // }
 }


### PR DESCRIPTION
Added notes on instrumenting NextJs client pages and Turbopack. We've received requests for guidance on configuring Turbopack, and questions on instrumenting files that are rendered to the client, both of which require minimal changes to an application. 