### PR TITLE
Update openai app to use `gpt-5.2`

### DIFF
--- a/ai-monitoring/openai/README.md
+++ b/ai-monitoring/openai/README.md
@@ -1,6 +1,6 @@
-# Sample OpenAI Application
+# Example OpenAI Application
 
-This application demonstrates using the agent to instrument openai and record spans for chat completions and embeddings.  It also will generate LlmChatCompletionMessage, LlmChatCompletionSummary, LlmEmbedding, and LlmFeedbackMessage to be used in the [New Relic AI Monitoring](https://newrelic.com/platform/ai-monitoring).
+This application demonstrates using the agent to instrument OpenAI and record spans for chat completions and embeddings.  It also will generate `LlmChatCompletionMessage`, `LlmChatCompletionSummary`, `LlmEmbedding`, and `LlmFeedbackMessage` events to be used in the [New Relic AI Monitoring](https://newrelic.com/platform/ai-monitoring) experience.
 
 ## Getting started
 
@@ -16,24 +16,74 @@ cp .env.sample .env
 npm start
 ```
 
-1. Make requests to application.
+
+
+## Make requests to application
+
+### Chat Completions API
+
+**Note**: The default chat model is `gpt-5.2`. GPT-5 family models do not support the `temperature` parameter; if you pass it, the API will return an error. Only use `temperature` with models that support it (e.g. `gpt-4`).
+
+`POST /chat-completion` - Accepts `{ message, model, temperature }`
+
+```sh
+curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/chat-completion \
+  -d '{"message":"How much wood could a woodchuck chuck if a woodchuck could chuck wood?"}'
+```
+
+With a model that supports `temperature`:
+
+```sh
+curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/chat-completion \
+  -d '{"message":"Tell me a joke", "model":"gpt-4o", "temperature":0.5}'
+```
+
+`POST /chat-completion-stream` - Accepts `{ message, model, temperature }`
+
+```sh
+curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/chat-completion-stream \
+  -d '{"message":"Explain the rules of jai alai"}'
+```
+
+### Responses API
+
+`POST /responses-create` - Accepts `{ message, model }`
+
+```sh
+curl -XPOST http://localhost:3000/responses-create
+curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/responses-create \
+  -d '{"message":"What is the capital of France?"}'
+```
+
+`POST /responses-create-stream` - Accepts `{ message, model }`
+
+```sh
+curl -XPOST http://localhost:3000/responses-create-stream
+curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/responses-create-stream \
+  -d '{"message":"Tell me a story", "model":"gpt-5.2"}'
+```
+
+### Embeddings
+
+`POST /embedding` - Accepts `{ input, model }`
 
 ```sh
 curl -XPOST http://localhost:3000/embedding
+curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/embedding \
+  -d '{"input":"Hello world", "model":"text-embedding-3-small"}'
+```
 
-curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/chat-completion -d '{"message":"How much wood could a woodchuck chuck if a woodchuck could chuck wood?"}'
+### Feedback
 
-# To leave feedback copy the id from response
-curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/feedback -d '{"id":"<response_id>"}'
+`POST /feedback` - Accepts `{ id, category, rating, message, metadata }`
 
-curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/chat-completion-stream -d '{"message":"Explain the rules of jai alai"}'
+After making a chat completion or response request, copy the `id` from the response to submit feedback:
 
-# To leave feedback copy the id from response
-curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/feedback -d '{"id":"<response_id>"}'
-
-# Using the new Responses API introduced in openai@5.0.0
-curl -XPOST http://localhost:3000/responses-create
-curl -XPOST http://localhost:3000/responses-create-stream
+```sh
+curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/feedback \
+  -d '{"id":"<response_id>"}'
+curl -XPOST -H 'Content-Type: application/json' http://localhost:3000/feedback \
+  -d '{"id":"<response_id>", "category":"feedback-test", "rating":1, "message":"Good talk"}'
 ```
 
 ## Inspecting AI Responses

--- a/ai-monitoring/openai/index.js
+++ b/ai-monitoring/openai/index.js
@@ -13,8 +13,8 @@ const openai = new OpenAI({
   apiKey
 })
 const { randomUUID: uuid } = require('node:crypto')
-
 const responses = new Map()
+const defaultChatModel = 'gpt-5.2'
 
 fastify.listen({ host, port }, function (err, address) {
   if (err) {
@@ -24,7 +24,7 @@ fastify.listen({ host, port }, function (err, address) {
 })
 
 fastify.post('/embedding', async (request, reply) => {
-  const { input = 'Test embedding', model = 'text-embedding-ada-002' } = request.body || {}
+  const { input = 'Test embedding', model = 'text-embedding-3-small' } = request.body || {}
   const embedding = await openai.embeddings.create({
     input,
     model
@@ -33,14 +33,14 @@ fastify.post('/embedding', async (request, reply) => {
 })
 
 fastify.post('/chat-completion', async(request, reply) => {
-  const { message = 'Say this is a test', model = 'gpt-4' } = request.body || {}
+  const { message = 'Say this is a test', model = defaultChatModel, temperature = 1 } = request.body || {}
 
   // assign conversation_id via custom attribute API
   const conversationId = uuid()
   newrelic.addCustomAttribute('llm.conversation_id', conversationId)
 
   const chatCompletion = await openai.chat.completions.create({
-    temperature: 0.5,
+    temperature,
     messages: [{ role: 'user', content: message }],
     model
   })
@@ -51,10 +51,10 @@ fastify.post('/chat-completion', async(request, reply) => {
 })
 
 fastify.post('/chat-completion-stream', async(request, reply) => {
-  const { message = 'Say this is a test', model = 'gpt-4' } = request.body || {}
+  const { message = 'Say this is a test', model = defaultChatModel, temperature = 1 } = request.body || {}
   const stream = await openai.chat.completions.create({
     stream: true,
-    temperature: 0.5,
+    temperature,
     messages: [{ role: 'user', content: message }],
     model
   })
@@ -95,7 +95,7 @@ fastify.post('/feedback', (request, reply) => {
 })
 
 fastify.post('/responses-create', async (request, reply) => {
-  const { message = 'Say this is a test', model = 'gpt-4' } = request.body || {}
+  const { message = 'Say this is a test', model = defaultChatModel } = request.body || {}
 
   // assign conversation_id via custom attribute API
   const conversationId = uuid()
@@ -112,7 +112,7 @@ fastify.post('/responses-create', async (request, reply) => {
 })
 
 fastify.post('/responses-create-stream', async (request, reply) => {
-  const { message = 'Say this is a test.', model = 'gpt-4' } = request.body || {}
+  const { message = 'Say this is a test.', model = defaultChatModel } = request.body || {}
 
   // assign conversation_id via custom attribute API
   const conversationId = uuid()


### PR DESCRIPTION
Cleaned up the README for the `ai-monitoring/openai` example app and had it use `gpt-5.2` as the default. `gpt-5.x` doesn't support temperature like `gpt-4.x` did, so I updated the endpoints to account for that.

Closes https://github.com/newrelic/node-newrelic/issues/3780