### PR TITLE
chore: Update Anthropic app's `newrelic` dep version and README

### DIFF
--- a/ai-monitoring/README.md
+++ b/ai-monitoring/README.md
@@ -1,9 +1,25 @@
 ## AI Monitoring
 
-This folder contains example applications interacting with various LLM libraries that produce [AI monitoring telemetry](https://docs.newrelic.com/docs/ai-monitoring/intro-to-ai-monitoring/)
+Example applications that demonstrate [New Relic AI Monitoring](https://docs.newrelic.com/docs/ai-monitoring/intro-to-ai-monitoring/) across a variety of LLM SDKs and agentic AI frameworks.
 
-* [AWS Bedrock](./aws-bedrock-app) - AWS Bedrock example that can make requests to all [supported LLM models](https://aws.amazon.com/ai/generative-ai/).
-* [MCP SDK](./mcp-sdk) - Two ModelContextProtocol examples: one using `@openai/agents` (which uses `StdioTransport`) and the other using `openai` and `StreamableHTTPTransport`.
-* [Langchain](./langchain) - [Langchain.js](https://js.langchain.com/v0.2/docs/introduction/) example that interacts with chains, vector stores, and tools.
-* [OpenAI](./openai) - [OpenAI](https://github.com/openai/openai-node) example that can make requests to create chat completions and embeddings.
-* [Gemini AI](./google-genai)- [Google SDK for Gemini and Vertex AI](https://github.com/googleapis/js-genai) example that can make requests to create chat completions and embeddings.
+### LLM SDKs
+
+When you enable AI monitoring, the New Relic Node.js agent can give you end-to-end visibility into performance, cost, and quality of [supported models](https://docs.newrelic.com/docs/apm/agents/nodejs-agent/getting-started/compatibility-requirements-nodejs-agent/#ai-monitoring-support) from vendors like OpenAI, Bedrock and Google Gemini. Explore how users interact with an AI assistant, dig into trace-level details about a model's response to an AI event, and compare the performance of different models across app environments.
+
+Learn more about this feature on [our docs website](https://docs.newrelic.com/docs/ai-monitoring/intro-to-ai-monitoring/).
+
+* [Anthropic](./anthropic) - Anthropic SDK example for chat completions, streaming, error instrumentation, and feedback recording.
+* [AWS Bedrock](./aws-bedrock-app) - Native AWS Bedrock SDK example for chat completions, streaming, embeddings, and the Converse API across multiple LLM models.
+* [Gemini AI](./google-genai) - Google GenAI (`@google/genai`) example for chat completions and embeddings supporting both Gemini AI and Vertex AI.
+* [LangChain + AWS](./langchain-aws) - LangChain.js (`@langchain/aws`) example using AWS Bedrock for chat completions, streaming, and embeddings via the Converse API.
+* [LangChain + OpenAI](./langchain-openai) - LangChain.js example using OpenAI for chat completions, streaming, vector stores (in-memory and Elasticsearch), and tool use.
+* [OpenAI](./openai) - OpenAI SDK example for chat completions (Chat Completions and Responses APIs), streaming, and embeddings.
+
+### Agentic AI
+
+Enabling AI monitoring also lets you observe the performance of your AI agents end-to-end. When your application runs a multi-step agentic workflow, New Relic captures the full execution, every agent invocation, every tool call, every handoff, so you can understand what happened, where it slowed down, and where something went wrong.
+
+Learn more about this feature on [our docs website](https://docs.newrelic.com/docs/ai-monitoring/explore-ai-data/view-ai-agents/).
+
+* [LangGraph](./langgraph) - LangGraph example using OpenAI for agent-based workflows with tools, a simple chatbot, and streaming.
+* [MCP SDK](./mcp-sdk) - Two `@modelcontextprotocol/sdk` examples: `stdio` uses `@openai/agents` with `StdioTransport`, and `streamable-http` demonstrates `StreamableHTTPTransport` directly and via `@openai/agents`.

--- a/ai-monitoring/anthropic/package.json
+++ b/ai-monitoring/anthropic/package.json
@@ -14,8 +14,8 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.33.0",
+    "@anthropic-ai/sdk": ">=0.33.0",
     "fastify": "^4.24.3",
-    "newrelic": "^13.18.0"
+    "newrelic": "^13.19.0"
   }
 }


### PR DESCRIPTION
* Updated the Anthropic example app's `newrelic` depedency version to accurately reflect when the instrumentation was released
* Updated the `ai-monitoring/README.md` to include Anthropic and other LLM/agentic AI packages.