### PR TITLE
chore: Clarify GCP vs Gemini Key env vars, update Gemini model id

### DIFF
--- a/ai-monitoring/google-genai/README.md
+++ b/ai-monitoring/google-genai/README.md
@@ -8,22 +8,27 @@ This app supports both Gemini AI and Vertex AI. Specify which one you want with 
 
 **Note**: This application requires the use of Node.js v20+.
 
-1. Make a [Google Cloud project](https://console.cloud.google.com/) and a [Gemini API Key](https://aistudio.google.com/app/apikey).
+1. Make a [Google Cloud project](https://console.cloud.google.com/) or a [Gemini API Key](https://aistudio.google.com/app/apikey).
 2. Clone or fork this repository.
 3. Install dependencies and run application.
 
    ```sh
    npm i
    cp env.sample .env
-   # Fill out `GEMINI_API_KEY`, `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, `NEW_RELIC_LICENSE_KEY` in .env and save 
+   # Fill out `NEW_RELIC_LICENSE_KEY`, `GEMINI_API_KEY` or `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` in .env and save 
    npm start
    ```
 4. Make requests to application.
 
    ```sh
-   curl http://localhost:3000/ # Basic generate content example
-   curl http://localhost:3000/stream # Generate content stream example
-   curl http://localhost:3000/embed # Embed content example
+   # Basic generate content example
+   curl http://localhost:3000/
+
+   # Generate content stream example
+   curl http://localhost:3000/stream
+
+   # Embed content example
+   curl http://localhost:3000/embed
    ```
 
 ## Inspecting AI Responses

--- a/ai-monitoring/google-genai/env.sample
+++ b/ai-monitoring/google-genai/env.sample
@@ -1,7 +1,9 @@
 NEW_RELIC_LICENSE_KEY=
 NEW_RELIC_APP_NAME=gemini-app
+# specify GOOGLE_CLOUD env vars or GEMINI_API KEY, not both
 GOOGLE_CLOUD_PROJECT=
 GOOGLE_CLOUD_LOCATION=
 GEMINI_API_KEY=
-# leave blank or keep commented to set to false
+# if you are using a Google Cloud project, set this to True
+# if using a Gemini API key, leave blank
 # GOOGLE_GENAI_USE_VERTEXAI=

--- a/ai-monitoring/google-genai/index.js
+++ b/ai-monitoring/google-genai/index.js
@@ -16,6 +16,8 @@ const GOOGLE_GENAI_USE_VERTEXAI = process.env.GOOGLE_GENAI_USE_VERTEXAI ?? false
 const app = express()
 const port = 3000
 
+const geminiModel = 'gemini-2.5-flash'
+
 // Determine which client to use
 let aiClient
 if (GOOGLE_GENAI_USE_VERTEXAI) {
@@ -34,7 +36,7 @@ if (GOOGLE_GENAI_USE_VERTEXAI) {
 app.get('/', async (req, res) => {
   try {
     const response = await aiClient.models.generateContent({
-      model: 'gemini-2.0-flash',
+      model: geminiModel,
       contents: 'Why is the sky blue?',
       config: {
         candidateCount: 2,
@@ -55,7 +57,7 @@ app.get('/', async (req, res) => {
 app.get('/stream', async (req, res) => {
   try {
     const response = await aiClient.models.generateContentStream({
-      model: 'gemini-2.0-flash',
+      model: geminiModel,
       contents: 'Write a story about a magic backpack.',
       config: {
         maxOutputTokens: 10000,


### PR DESCRIPTION
While I was helping another agent engineer with Google Cloud, I realized our Google Gen AI (Gemini) standalone app was a bit outdated, so I updated it.

* Gemini model ID updated to `'gemini-2.5-flash'` and now only has to be changed in one place
* Clarified when to use `GEMINI_API_KEY` and `GOOGLE_CLOUD_*` env vars
