### PR TITLE
chore: Updated app router example to wait for agent to connect and require `dotenv` in config to load `.env` for new relic config

### DIFF
--- a/nextjs/nextjs-app-router/app/layout.js
+++ b/nextjs/nextjs-app-router/app/layout.js
@@ -15,22 +15,19 @@ import Link from 'next/link'
 import './style.css'
 
 export default async function RootLayout({ children }) {
-  // During `next build` the New Relic agent is not running (--require newrelic
-  // is only in the start/dev scripts, not the build script). Requiring newrelic
-  // at build time initializes the agent, which then waits indefinitely for a
-  // 'connected' event that never fires, hanging every page worker.
-  // NEXT_PHASE is set to 'phase-production-build' only during `next build`.
-  let browserTimingHeader = ''
-  if (process.env.NEXT_PHASE !== 'phase-production-build') {
-    const newrelic = require('newrelic')
+  const newrelic = require('newrelic')
+  // getBrowserTimingHeader returns an empty string when the agent is not yet
+  // connected, so wait for agent to connect
+  if (newrelic.agent.collector.isConnected() === false) {
+    await new Promise((resolve) => {
+      newrelic.agent.on('connected', resolve)
+    })
+  }
 
-    // getBrowserTimingHeader returns an empty string when the agent is not yet
-    // connected (e.g. missing license key), so no connection wait is needed.
-    browserTimingHeader = newrelic.getBrowserTimingHeader({
+  const browserTimingHeader = newrelic.getBrowserTimingHeader({
       hasToRemoveScriptWrapper: true,
       allowTransactionlessInjection: true,
     })
-  }
 
   return (
     <html>

--- a/nextjs/nextjs-app-router/newrelic.js
+++ b/nextjs/nextjs-app-router/newrelic.js
@@ -1,4 +1,5 @@
 'use strict'
+require('dotenv').config()
 
 /**
  * New Relic agent configuration.

--- a/nextjs/nextjs-app-router/package.json
+++ b/nextjs/nextjs-app-router/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
-    "build": "NODE_OPTIONS='--require dotenv/config' next build",
-    "start": "NODE_OPTIONS='--require dotenv/config --require newrelic --import newrelic/esm-loader.mjs' next start",
+    "build": "NODE_OPTIONS='--require newrelic --import newrelic/esm-loader.mjs' next build",
+    "start": "NODE_OPTIONS='--require newrelic --import newrelic/esm-loader.mjs' next start",
     "lint": "eslint ."
   },
   "dependencies": {


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->
In #374 the app was refactored to work with Next 16 and show how to use turbopack. During that refactor, injecting the browser agent broke. This PR resolves that by waiting for the agent to be connected before getting the browser agent header.  Also combines `dotnev` in config as next.js 16 messes with `NODE_OPTIONS` and combines duplicate cli args.  to `--require dotenv/config` and `--require newrelic` would be `--require dotenv/config newrelic` which no longer works, yay Next.js!
