### PR TITLE
feat: Updated Lambda test for OTEL metrics verification

### DIFF
--- a/lambda-test/Dockerfile
+++ b/lambda-test/Dockerfile
@@ -17,7 +17,7 @@ FROM public.ecr.aws/newrelic-lambda-layers-for-docker/newrelic-lambda-layers-lam
 FROM nr-ext-${TARGETARCH} AS nr-ext
 
 # This FROM clause specifies our actual base image.
-FROM public.ecr.aws/lambda/nodejs:26
+FROM public.ecr.aws/lambda/nodejs:24
 
 # This FROM clause copies in the New Relic Lambda extension.
 COPY --from=nr-ext /opt/ /opt/

--- a/lambda-test/Dockerfile
+++ b/lambda-test/Dockerfile
@@ -1,4 +1,26 @@
-FROM public.ecr.aws/lambda/nodejs:22
+## We can replicate utilizing the New Relic Lambda extension by utilizing
+## the Docker layers available at:
+## https://gallery.ecr.aws/newrelic-lambda-layers-for-docker/newrelic-lambda-layers-lambdaextension
+##
+## If this is not desired, simply comment out the `COPY --from=nr-ext` line.
+##
+## Note: as of 2026-07, the above registry does not have floating tags for the
+## latest layers. So we must specify a specific version.
+##
+## TARGETARCH is set automatically by BuildKit ("amd64" or "arm64").
+## The New Relic extension image tags the arm64 build as "2.6.3-arm64"
+## and the amd64 build as bare "2.6.3", so map arch -> tag suffix here.
+ARG TARGETARCH
+ARG NR_EXT_VERSION=2.6.3
+FROM public.ecr.aws/newrelic-lambda-layers-for-docker/newrelic-lambda-layers-lambdaextension:${NR_EXT_VERSION}-arm64 AS nr-ext-arm64
+FROM public.ecr.aws/newrelic-lambda-layers-for-docker/newrelic-lambda-layers-lambdaextension:${NR_EXT_VERSION} AS nr-ext-amd64
+FROM nr-ext-${TARGETARCH} AS nr-ext
+
+# This FROM clause specifies our actual base image.
+FROM public.ecr.aws/lambda/nodejs:26
+
+# This FROM clause copies in the New Relic Lambda extension.
+COPY --from=nr-ext /opt/ /opt/
 
 # Copy function code
 COPY . ${LAMBDA_TASK_ROOT}

--- a/lambda-test/README.md
+++ b/lambda-test/README.md
@@ -1,5 +1,7 @@
 # Local Lambda Tests
-This application uses a lambda runtime container to simulate running a Node.js function in Lambda with(out) the New Relic Node.js agent.
+This application uses a [lambda runtime container](https://gallery.ecr.aws/lambda/nodejs)
+to simulate running a Node.js function in Lambda with or without the New Relic
+Node.js agent.
 
 ## Setup
 
@@ -7,7 +9,7 @@ This application uses a lambda runtime container to simulate running a Node.js f
 cp env.sample .env
 # If you want to change the type of handler invoked, change `FUNCTION_MODE`
 # Supported values: `async`, `context`, `cb`, `streaming`. 
-# If you want to run lambda without agent set `NEW_RELIC_ENABLED` to `false`
+# If you want to run lambda without the agent set `NEW_RELIC_ENABLED` to `false`
 # Build container
 docker build -t lambda-test .
 ```
@@ -24,9 +26,32 @@ docker run -p 9900:8080 -p 9229:9229 --env-file .env lambda-test:latest
 curl -XPOST "http://localhost:9900/2015-03-31/functions/function/invocations" -d '{"payload":"hello world!"}'
 ```
 
+Or, as a complete example:
+
+```sh
+docker build --tag lambda-test . && \
+docker run --rm -p 9900:8080 -p 9229:9229 --name lambda --env-file .env lambda-test:latest && \
+docker image rm lambda-test
+```
+
+Running the above will compile the image, start the container, and then
+remove the container plus image once <kbd>ctrl</kbd>+<kbd>c</kbd> is pressed.
+
 ## Notes
-If you want to install the latest agent and not rely on a locally installed agent, uncomment the following line from Dockerfile.
+If you want to install the latest agent and not rely on a locally installed
+agent, uncomment the following line from Dockerfile.
 
 ```sh
 #RUN npm install
 ```
+
+## Testing Open Telemetry Metrics
+
+To test that the New Relic agent's Open Telemetry (OTEL) metrics support works,
+the following environment variables must be added to the `.env` file:
+
+```sh
+NEW_RELIC_OPENTELEMETRY_ENABLED=true
+NEW_RELIC_OPENTELEMETRY_METRICS_ENABLED=true
+```
+Additionally, the `async` handler must be used (`FUNCTION_MODE=async`).

--- a/lambda-test/app.js
+++ b/lambda-test/app.js
@@ -4,7 +4,12 @@
  */
 
 'use strict'
+
 const newrelic = require('newrelic')
+
+// Bootstrap the metrics object for the current invocation:
+require('./lib/metrics.js')
+
 const mode = process.env.FUNCTION_MODE
 const agentEnabled = process.env.NEW_RELIC_ENABLED
 const asyncHandler = require('./handlers/async')

--- a/lambda-test/env.sample
+++ b/lambda-test/env.sample
@@ -1,10 +1,19 @@
+## See https://docs.newrelic.com/docs/serverless-function-monitoring/aws-lambda-monitoring/instrument-lambda-function/env-variables-lambda/
+
 NEW_RELIC_LOG=stdout
 NEW_RELIC_LOG_ENABLED=true
 NEW_RELIC_LOG_LEVEL=trace
 NEW_RELIC_APP_NAME=lambda-test
 NEW_RELIC_SERVERLESS_MODE_ENABLED=true
 NEW_RELIC_ACCOUNT_ID=1
+NEW_RELIC_LICENSE_KEY=your-key
+
 # Allowed values `async`, `context`, `cb`, or `streaming`
 FUNCTION_MODE=async
+
 # set next to false if you want to run without agent
 NEW_RELIC_ENABLED=true
+
+# Enable OTEL bridge and metrics
+NEW_RELIC_OPENTELEMETRY_ENABLED=true
+NEW_RELIC_OPENTELEMETRY_METRICS_ENABLED=true

--- a/lambda-test/handlers/async.js
+++ b/lambda-test/handlers/async.js
@@ -4,7 +4,12 @@
  */
 
 'use strict'
+
+const metrics = require('../lib/metrics.js')
+
 module.exports = async function lambdaHandler() {
+  metrics.integers.add(1)
+
   const req = await Promise.resolve({ hello: 'world' })
   return req
 }

--- a/lambda-test/lib/metrics.js
+++ b/lambda-test/lib/metrics.js
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2026 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+'use strict'
+
+const otel = require('@opentelemetry/api')
+
+module.exports = {
+  integers: otel.metrics.getMeter('lambda-meter').createCounter('integers')
+}

--- a/lambda-test/package.json
+++ b/lambda-test/package.json
@@ -10,6 +10,6 @@
   "description": "",
   "dependencies": {
     "@opentelemetry/api": "^1.9.1",
-    "newrelic": "^14.3.0"
+    "newrelic": "^14.3.4"
   }
 }

--- a/lambda-test/package.json
+++ b/lambda-test/package.json
@@ -9,6 +9,7 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
-    "newrelic": "^12.15.0"
+    "@opentelemetry/api": "^1.9.1",
+    "newrelic": "^14.3.0"
   }
 }


### PR DESCRIPTION
This PR goes with https://github.com/newrelic/node-newrelic/pull/4166. It updates the `lambda-test` such that we can use it to verify the New Relic Lambda extension forwards the `otlp_payload` correctly when the agent harvests. We are able to verify this by installing the agent from the linked branch and adding a debug line to `lib/collector/serverless.js` at 174:

```js
process._rawDebug('!!! toFlush:', toFlush)
```

Upon running the container with the correct agent revision and the above debug line, we will see the data is being added correctly.

What is not clear at the moment is if the extension actually does anything with it. I don't have any data in my NR dashboard to indicate that it does at this time.

Note: we must wait to merge this PR until it can be updated with a `newrelic` version string that includes the required scaffolding.